### PR TITLE
Improve tooling to automatically create canvas-lms base boxes. Includes:

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Canvas LMS Vagrant Box
 ======================
 
+Installs a recent bootstrapped canvas via vagrant and virtualbox.
+
 Requirements
 ------------
 
@@ -12,26 +14,24 @@ Quickstart
 
     git clone http://github.com/djcp/canvas_vagrant
     cd canvas_vagrant
-    vagrant up
+    vagrant box update # Only if you've used this before
+    vagrant up # Time passes. . .
     vagrant ssh
 
-Stuff will happen, including downloading a large-ish ubuntu 14.04 VM including
-a modern ruby dev environment.
-
-You should see instructions in the vagrant SSH session telling you how to spin
-up the canvas LMS and how to access it in your virtualbox host.
-
-If you're happy configuring your vagrant box from scratch, you could:
-
-    mkdir canvas_vagrant && cd canvas_vagrant
-    vagrant init harvard-dce/ubuntu-14-04-canvas-lms
-    vagrant up
-    vagrant ssh
-
-but you'd be missing the port forwarding and VM tuning included in this repo.
-
-VM config overview
+Vagrant box overview
 ------------------
+
+The vagrant box includes:
+
+* A 2gb RAM allocation (canvas requires this much RAM to run acceptably),
+* A recent-ish canvas as of the time the base box was created, from the `master` branch,
+* A migrated and seeded database,
+* Rendered assets,
+* Canvas is exported on http://192.168.50.4:3000/ (after you've started it),
+* A `Procfile.dev` to make starting canvas easier.
+
+You should see specific instructions in the vagrant SSH session telling you
+how to spin up the canvas LMS and how to access it in your virtualbox host.
 
 `postgres` is configured to use ident auth. You can access the development
 databases within the vagrant box thusly:
@@ -49,19 +49,18 @@ documented in the `motd` you get when `vagrant ssh`ing.
 
 `rbenv` is used to manage rubies.
 
-Coming Soon?
-============
+Notes
+-----
 
-* Provisioning via [ansible](http://ansible.com)
-* Multiple providers
-* Automated repackaging based on new canvas releases
+You should run `vagrant box list` and remove any old versions of the box this
+provides when you're done with them, otherwise they could take up a significant
+amount of disk space.
 
 See also
 ========
 
 * [virtualbox](http://virtualbox.org)
 * [vagrant](http://vagrantup.com)
-* [laptop](http://github.com/thoughtbot/laptop)
 * [canvas](http://github.com/instructure/canvas-lms)
 
 Copyright

--- a/README_DEV.md
+++ b/README_DEV.md
@@ -1,0 +1,7 @@
+Developers Only
+===============
+
+* Make sure you have the aws-cli installed as provided by amazon, in addition to the base requirements.
+* Ensure you can upload files to the relevant s3 bucket via the aws-cli s3 interface.
+* Run `./bin/publish_updated_base_box.sh` to re-render and upload a new canvas box.
+* After uploading a new box, you should "create a new version" on the [atlas](https://atlas.hashicorp.com) site to ensure users get the latest and greatest.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,7 @@
 Vagrant.configure('2') do |config|
   config.vm.box = "harvard-dce/ubuntu-14-04-canvas-lms"
-  config.vm.network "forwarded_port", guest: 3000, host: 33000
+  config.vm.network :private_network, ip: "192.168.50.4"
+
   config.vm.provider :virtualbox do |vb|
     vb.customize ["modifyvm", :id, "--memory", "2048"]
   end

--- a/bin/publish_updated_base_box.sh
+++ b/bin/publish_updated_base_box.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+bucket_name='dce-vagrant-images'
+
+message() {
+  printf "\e[1;34m:: \e[1;37m%s\e[0m\n" "$*"
+}
+
+failure_message() {
+  printf "\n\e[1;31mFAILURE\e[0m: \e[1;37m%s\e[0m\n\n" "$*" >&2;
+}
+
+check_for_aws() {
+  if ! command -v aws &>/dev/null; then
+    failure_message 'You must install aws-cli to publish boxes'
+    exit 1
+  fi
+}
+
+upload_box_to_temp_location(){
+  message "Uploading box to s3: $box"
+  aws s3 cp "$box" "s3://$bucket_name/$box.tmp" --acl public-read
+}
+
+move_box_into_place(){
+  message "Removing existing box: $box"
+  aws s3 rm "s3://$bucket_name/$box" \
+    || failure_message "Could not remove $box"
+
+  message "Moving new box to correct location: $box"
+  aws s3 mv "s3://$bucket_name/$box.tmp" "s3://$bucket_name/$box" \
+    --acl public-read || failure_message 'Could not move new box into place on s3'
+}
+
+publish_box(){
+  upload_box_to_temp_location && move_box_into_place
+}
+
+###################################
+
+check_for_aws
+
+cd canvas_base_box
+echo 'Remove already rendered base box to force re-provisioning and updating'
+vagrant destroy
+rm -f *.box
+
+if vagrant up; then
+  vagrant package --base "canvas-lms_base_box" --output "ubuntu-14-04-canvas-lms.box"
+fi
+
+for box in *.box; do
+  publish_box
+  echo "You should now release another atlas (née 'vagrantcloud') version for harvard-dce/$box"
+done

--- a/canvas_base_box/Procfile.dev
+++ b/canvas_base_box/Procfile.dev
@@ -1,0 +1,2 @@
+web: bundle exec rails server
+worker: bundle exec script/delayed_job run

--- a/canvas_base_box/Vagrantfile
+++ b/canvas_base_box/Vagrantfile
@@ -1,0 +1,27 @@
+Vagrant.configure(2) do |config|
+  config.vm.box = "harvard-dce/ubuntu-14-04-post-install"
+  config.vm.network :private_network, ip: "192.168.50.4"
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ["modifyvm", :id, "--memory", "2048"]
+    vb.name = "canvas-lms_base_box"
+  end
+
+  config.vm.provision 'file',
+    source: './canvas_initial_setup.exp',
+    destination: '~/.canvas_initial_setup.exp'
+
+  config.vm.provision 'file',
+    source: './bashrc_additions.sh',
+    destination: '~/.bashrc_additions.sh'
+
+  config.vm.provision 'shell',
+    path: 'provision_root_items.sh'
+
+  config.vm.provision 'shell',
+    path: 'configure_ruby_and_canvas.sh',
+    privileged: false
+
+  config.vm.provision 'file',
+    source: './Procfile.dev',
+    destination: '~/canvas-lms/Procfile.dev'
+end

--- a/canvas_base_box/bashrc_additions.sh
+++ b/canvas_base_box/bashrc_additions.sh
@@ -1,0 +1,24 @@
+last_commit=$(cd ~/canvas-lms && git log -n 1)
+branch=$(cd ~/canvas-lms && git branch --no-color 2> /dev/null | grep '*' | sed  's/\* //')
+
+echo "
+*******************************
+To run canvas:
+> cd ~/canvas-lms
+> foreman start -f Procfile.dev
+
+Wait about 30 seconds for the web interface to spin up, then it should
+be available on:
+
+http://192.168.50.4:3000/
+
+username: vagrant@example.com
+password: vagrant
+
+*******************************
+Last commit on \"$branch\" branch:
+
+$last_commit
+
+Happy canvassing!
+"

--- a/canvas_base_box/canvas_initial_setup.exp
+++ b/canvas_base_box/canvas_initial_setup.exp
@@ -1,0 +1,21 @@
+spawn bundle exec rake db:initial_setup
+
+expect "What email address will the site administrator account use*"
+send "vagrant@example.com\r"
+
+expect "Please confirm*"
+send "vagrant@example.com\r"
+
+expect "What password will the site administrator use*"
+send "vagrant\r"
+
+expect "Please confirm*"
+send "vagrant\r"
+
+expect "the name of your organization.*"
+send "Canvas vagrant dev\r"
+
+expect "3. Opt out completely*"
+send "3\r"
+
+expect eof

--- a/canvas_base_box/configure_ruby_and_canvas.sh
+++ b/canvas_base_box/configure_ruby_and_canvas.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+trap 'ret=$?; test $ret -ne 0 && printf "failed\n\n" >&2; exit $ret' EXIT
+
+echo "gem: --no-rdoc --no-ri" >> /home/vagrant/.gemrc
+echo "source ~/.bashrc_additions.sh" >> ~/.bashrc
+
+git clone git://github.com/sstephenson/rbenv.git /home/vagrant/.rbenv
+printf 'export PATH="$HOME/.rbenv/bin:$PATH"\n' >> /home/vagrant/.profile
+printf 'eval "$(rbenv init - --no-rehash)"\n' >> /home/vagrant/.profile
+
+git clone https://github.com/sstephenson/rbenv-gem-rehash.git /home/vagrant/.rbenv/plugins/rbenv-gem-rehash
+git clone git://github.com/sstephenson/ruby-build.git /home/vagrant/.rbenv/plugins/ruby-build
+
+source ~/.profile
+# This will find the latest official ruby release supported by ruby-build
+# mri_ruby_version=$(rbenv install -l | egrep " [[:digit:]]\.[[:digit:]]\.[[:digit:]]$" | tail -1)
+
+# This will find the latest 2.1.x ruby release supported by ruby-build
+mri_ruby_version=$(rbenv install -l | egrep " 2\.1\.[[:digit:]]$" | tail -1)
+
+rbenv install ${mri_ruby_version}
+rbenv global ${mri_ruby_version}
+rbenv rehash
+
+gem install foreman
+gem install bundler -v 1.6.0
+git clone https://github.com/instructure/canvas-lms canvas-lms
+cd canvas-lms
+git checkout master
+bundle install --without mysql
+
+for config in amazon_s3 database delayed_jobs domain file_store outgoing_mail security external_migration;
+do cp -v config/${config}.yml.example config/${config}.yml; done
+
+createdb canvas_development
+createdb canvas_queue_development
+expect < ~/.canvas_initial_setup.exp
+
+npm install
+bundle exec rake canvas:compile_assets

--- a/canvas_base_box/provision_root_items.sh
+++ b/canvas_base_box/provision_root_items.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+trap 'ret=$?; test $ret -ne 0 && printf "failed\n\n" >&2; exit $ret' EXIT
+
+aptitude update
+aptitude install -y \
+  htop\
+  expect\
+  build-essential\
+  git\
+  libxslt1-dev\
+  libcurl4-openssl-dev\
+  libksba8\
+  libksba-dev\
+  libqtwebkit-dev\
+  libreadline-dev\
+  libsqlite3-dev\
+  sqlite3\
+  postgresql\
+  postgresql-server-dev-all\
+  redis-server\
+  vim-nox\
+  imagemagick\
+  silversearcher-ag\
+  nodejs\
+  npm
+
+ln -s /usr/bin/nodejs /usr/bin/node
+
+sudo -u postgres createuser -d vagrant
+
+aptitude build-dep -y ruby2.0
+
+npm install -g coffee-script@1.6.2
+
+aptitude clean


### PR DESCRIPTION
- Provisioning as root and as the vagrant user where appropriate
- Pull down the latest master branch of canvas-lms
- Install all dependencies, create the databases, render assets and do
  everything needed to get a basic version of canvas running
- Document how to use the box in a post-login MOTD-like banner
- Tooling to automate uploading the new box to the correct location on s3
- Allocate 2gb of RAM to the vagrant image by default.
- [x] Update README
- [x] Switch from port forwarding to exporting on an RFC-1918 network address
